### PR TITLE
Import activatePluginInterfaces from canonical place in PlonePAS [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,18 +14,21 @@ New features:
 
 Bug fixes:
 
+- Import ``activatePluginInterfaces`` from the canonical place in ``Products.PlonePAS``.
+  [maurits]
+
 - Python 2 / 3 compat with six.
   [jensens]
 
-- Cleanup: 
+- Cleanup:
 
-    - No self-contained buildout, 
-    - utf8-headers, 
-    - isort, 
+    - No self-contained buildout,
+    - utf8-headers,
+    - isort,
     - ZCA-decorators
     - formatting/readability/pep8,
     - Security decorators
-  
+
   [jensens]
 
 - Fix test for Zope 4.

--- a/borg/localrole/utils.py
+++ b/borg/localrole/utils.py
@@ -3,8 +3,8 @@ from Acquisition import aq_base
 from borg.localrole.config import LOCALROLE_PLUGIN_NAME
 from borg.localrole.workspace import manage_addWorkspaceLocalRoleManager
 from Products.CMFCore.utils import getToolByName
-from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
 from Products.PlonePAS.plugins.local_role import LocalRolesManager
+from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from six import StringIO
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'zope.interface',
         'Products.CMFCore',
         'Products.GenericSetup',
-        'Products.PlonePAS',
+        'Products.PlonePAS >= 5.0.1',
         'Products.PluggableAuthService',
         'plone.memoize',
         'Acquisition',


### PR DESCRIPTION
This requires Products.PlonePAS 5.0.1 or later, which is used since Plone 4.3.8.