### PR TITLE
Import activatePluginInterfaces from canonical place in PlonePAS [3.0.x]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Import ``activatePluginInterfaces`` from the canonical place in ``Products.PlonePAS``.
+  This was moved from ``Extensions/Install.py`` to ``setuphandlers.py`` in PlonePAS 5.0.1.
+  We try both places for backwards compatibility.  [maurits]
 
 
 3.0.2 - 2010-10-27
@@ -62,7 +64,7 @@ Changelog
 - Support caching of allowed local roles on the request.
   [witsch]
 
-- Renamed the default adapter to "default" so that people don't 
+- Renamed the default adapter to "default" so that people don't
   accidentally override it with an unnamed adapter. Overriding the default
   should be possible, but is a marginal use case. If it's overridden but
   not replicated properly, all sorts of problems can result.
@@ -77,4 +79,3 @@ Changelog
 ------------------
 
 - Baseline for Plone 3.1
-

--- a/borg/localrole/utils.py
+++ b/borg/localrole/utils.py
@@ -2,8 +2,13 @@ from StringIO import StringIO
 
 from Acquisition import aq_base
 from Products.CMFCore.utils import getToolByName
-from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
 from Products.PlonePAS.plugins.local_role import LocalRolesManager
+try:
+    # PlonePAS 5.0.1 or higher
+    from Products.PlonePAS.setuphandlers import activatePluginInterfaces
+except ImportError:
+    # PlonePAS exactly 5.0, or lower.
+    from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
 
 from borg.localrole.config import LOCALROLE_PLUGIN_NAME
 from borg.localrole.workspace import manage_addWorkspaceLocalRoleManager


### PR DESCRIPTION
This was moved from `Extensions/Install.py` to `setuphandlers.py` in PlonePAS 5.0.1.
We try both places for backwards compatibility, because the borg.localrole 3.0.x is used from Plone 4.0-4.3, so it seems good not to break earlier Plones (even when the versions are pinned).

Note that in the similar PR #7 for master, we only import from the new place.
